### PR TITLE
Small quality of life changes

### DIFF
--- a/ground/readout/create-plot.py
+++ b/ground/readout/create-plot.py
@@ -607,22 +607,11 @@ def main():
 
     fitlog_dt = datetime.now().astimezone().strftime("%Y-%m-%d_%H-%M-%S")
     fitlog_name = f"fitlog_{fitlog_dt}.log"
-
     fitlog_path = os.path.join(fitlog_dir, fitlog_name)
 
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    fitlog_copy_dir = os.path.abspath(os.path.join(script_dir, "..", "multi-run-logs"))
-    os.makedirs(fitlog_copy_dir, exist_ok=True)
-
-    fitlog_copy_path = os.path.join(fitlog_copy_dir, fitlog_name)
-
-    # Write to both destinations always
-    fitlog_paths = [fitlog_path, fitlog_copy_path]
-
     def flog_write(line: str):
-        for p in fitlog_paths:
-            with open(p, "a") as _f:
-                _f.write(line)
+        with open(fitlog_path, "a") as _f:
+            _f.write(line)
 
     for folder in plot_types:
         os.makedirs(os.path.join(plot_base_dir, folder), exist_ok=True)
@@ -775,9 +764,8 @@ def main():
     print("\n[INFO] Generating plots and fit log...")
     plot_t0 = time.time()
 
-    for p in fitlog_paths:
-        with open(p, "w") as _f:
-            pass
+    with open(fitlog_path, "w") as _f:
+        pass
 
     flog_write(f"fitlog created: {fitlog_dt}\n")
     flog_write(f"fits_dir: {fits_dir}\n")

--- a/ground/run-end-to-end.sh
+++ b/ground/run-end-to-end.sh
@@ -34,6 +34,7 @@ PROCESS_SCRIPT="$BASE_DIR/readout/process-exposures-batch.py"
 PLOT_SCRIPT="$BASE_DIR/readout/create-plot.py"
 LOAD_CONFIG="$BASE_DIR/load-config.py"
 ANIMATION_SCRIPT="$BASE_DIR/readout/create-animation.py"
+UNIFIED_MAKEFILE_DIR="$BASE_DIR"
 
 # Runtime state
 MODE="full"
@@ -73,6 +74,12 @@ Examples:
   ./run-end-to-end.sh --mode full --output-root ./campaign-20260319/run_001
   ./run-end-to-end.sh --mode process-only --exposure-dir ./campaign-20260319/run_001/exposures-20260319-...
 EOF
+}
+
+build_hardware_binaries() {
+  info "Ensuring camera and encoder binaries are up to date..."
+  make -C "$UNIFIED_MAKEFILE_DIR"
+  info "Build complete."
 }
 
 kill_pgrp() {
@@ -183,6 +190,10 @@ if [[ "$MODE" != "process-only" ]]; then
       exit 1
     fi
   done
+fi
+
+if [[ "$MODE" != "process-only" ]]; then
+  build_hardware_binaries
 fi
 
 info "Loading config: ${CONFIG_PATH}"

--- a/ground/run-end-to-end.sh
+++ b/ground/run-end-to-end.sh
@@ -305,8 +305,8 @@ run_processing_stage() {
     info "Deleting raw bin directory: ${EXPOSURE_DIR}/raw"
     rm -rf "${EXPOSURE_DIR}/raw" || true
 
-    info "Deleting processed FITS directory..."
-    rm -rf "${EXPOSURE_DIR}/processed/fits" || true
+    info "Deleting processed images directory..."
+    rm -rf "${EXPOSURE_DIR}/processed" || true
 
     info "Cleanup complete."
   fi


### PR DESCRIPTION
1. run-end-to-end.sh (and by extension multi-run.sh) will call the unified makefile to make sure hardware is on most recent version of compiled code before running. Resolves #27 
2. Small change to cleanup logic. Old cleanup routine would only delete .FITS files subdirectory. New logic now deletes entire 'processed/' subdirectory, deleting any .png files as well. Resolves #35 
3. multi-run.sh no longer copies fitlog files to 'multi-run-logs/' directory, which has now been deleted on the polarimeter filesystem. Each run inside of the multi-run campaign contains the fitlog in the same directory as output plots, which is easier to associate any given log file with its corresponding run. Resolves #29 